### PR TITLE
Add template.js.erb to Gemspec

### DIFF
--- a/js_from_routes.gemspec
+++ b/js_from_routes.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/ElMassimo/js_from_routes'
   s.license = 'MIT'
   s.extra_rdoc_files = ['README.md']
-  s.files = Dir.glob('{lib}/**/*.rb') + %w(README.md)
+  s.files = Dir.glob('{lib}/**/*.rb') + %w(README.md) + Dir.glob('{lib}/**/*.erb')
   s.test_files   = Dir.glob('{spec}/**/*.rb')
   s.require_path = 'lib'
 


### PR DESCRIPTION
When you install from RubyGems, the gem doesn't work because it doesn't include the `template.js.erb`. This is caused by it being missing from the Gemspec itself. The PR adds it to the Gemspec.